### PR TITLE
Fix download logic when image is not present

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
@@ -74,14 +73,19 @@ func (dc *simpleDockerContainer) getImage() error {
 		}
 	}
 	if repoDigest != "" {
-		fmt.Println("Failed to find image, pulling")
+		fmt.Println("Failed to find image but repo digest obtained, pulling")
 		reader, err := dc.client.ImagePull(dc.ctx, repoDigest, image.PullOptions{})
 		if err != nil {
 			panic(err)
 		}
 		io.Copy(os.Stdout, reader)
 	} else {
-		return errors.New(fmt.Sprintf("fail to find a repo digest with the image name %s", dc.imageName))
+		fmt.Println("Failed to find image, pulling using the image name")
+		reader, err := dc.client.ImagePull(dc.ctx, dc.imageName, image.PullOptions{})
+		if err != nil {
+			panic(err)
+		}
+		io.Copy(os.Stdout, reader)
 	}
 	return nil
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -14,7 +14,7 @@ import (
 var docker *simpleDockerContainer
 
 func setUp() {
-	fmt.Printf("Begin setUp() on the test environment")
+	fmt.Println("Begin setUp() on the test environment")
 	ctx = context.Background()
 	ver := os.Getenv("REDIS_VERSION")
 	if ver == "" {

--- a/integration_test.go
+++ b/integration_test.go
@@ -26,7 +26,7 @@ func setUp() {
 	docker = &simpleDockerContainer{}
 	err := docker.initialize(imageName, "6379")
 	if err != nil {
-		fmt.Println("We are in a real panic")
+		fmt.Println(fmt.Sprintf("We are in a real panic: %s", err.Error()))
 		panic(err)
 	}
 	hostname, port := docker.getContainerNetworkInfo()


### PR DESCRIPTION
Added extra logic to:
  1. Bail as soon as an error is encountered when listing images.
  2. Find the image tag from the full slice of tags since an image can be tagged more than once.
  3. Use the repo digest to download the image as the digest uses the sha.
  4. Fallback to download via image name when digest cannot be found.
  5. Also better error propagation overall.